### PR TITLE
Ermöglicht Nutzung ohne .env

### DIFF
--- a/web-isk/README.md
+++ b/web-isk/README.md
@@ -1,10 +1,10 @@
 # ISK Rechner
 
-Dieses Projekt ist eine einfache Single-Page-Webapp, welche Daten aus der EVE Online ESI Schnittstelle nutzt. Zur Nutzung muss eine `.env` Datei mit den folgenden Werten angelegt werden:
+Dieses Projekt ist eine einfache Single-Page-Webapp, welche Daten aus der EVE Online ESI Schnittstelle nutzt. Die Anwendung funktioniert ohne vorbereitete `.env`‑Datei. Beim ersten Login fragt die Oberfläche nach der benötigten Client‑ID, welche danach im Browser gespeichert wird. Alternativ kann wie bisher eine `.env` Datei mit folgenden Werten angelegt werden:
 
 ```
 VITE_EVE_CLIENT_ID=<Client-ID aus dem EVE Entwicklerportal>
 VITE_EVE_REDIRECT_URI=http://localhost:5173/
 ```
 
-Anschließend startet man die Entwicklungsumgebung mit `npm run dev`. Der Login erfolgt über die Schaltfläche "Login with EVE". Nach erfolgreicher Anmeldung können erste Wallet-Daten geladen werden.
+Im Anschluss startet man die Entwicklungsumgebung mit `npm run dev`. Der Login erfolgt über die Schaltfläche "Login with EVE". Nach erfolgreicher Anmeldung können erste Wallet-Daten geladen werden.

--- a/web-isk/src/auth.ts
+++ b/web-isk/src/auth.ts
@@ -7,6 +7,22 @@ export interface AuthToken {
 
 const ssoBase = 'https://login.eveonline.com/v2'
 
+function getClientId(): string {
+  const envId = import.meta.env.VITE_EVE_CLIENT_ID
+  if (envId) return envId
+  const stored = localStorage.getItem('eveClientId')
+  if (stored) return stored
+  const entered = prompt('EVE Client ID?')?.trim()
+  if (!entered) throw new Error('Missing EVE Client ID')
+  localStorage.setItem('eveClientId', entered)
+  return entered
+}
+
+function getRedirectUri(): string {
+  const envUri = import.meta.env.VITE_EVE_REDIRECT_URI
+  return envUri || `${window.location.origin}/`
+}
+
 function base64UrlEncode(input: ArrayBuffer): string {
   return btoa(String.fromCharCode(...new Uint8Array(input)))
     .replace(/\+/g, '-')
@@ -29,8 +45,8 @@ export async function generateCodeChallenge(verifier: string): Promise<string> {
 export function buildAuthorizeUrl(verifier: string, challenge: string): string {
   const params = new URLSearchParams({
     response_type: 'code',
-    client_id: import.meta.env.VITE_EVE_CLIENT_ID,
-    redirect_uri: import.meta.env.VITE_EVE_REDIRECT_URI,
+    client_id: getClientId(),
+    redirect_uri: getRedirectUri(),
     scope: 'esi-wallet.read_character_wallet.v1 esi-industry.read_character_jobs.v1 esi-industry.read_character_mining.v1',
     code_challenge: challenge,
     code_challenge_method: 'S256',
@@ -43,7 +59,7 @@ export async function fetchToken(code: string, verifier: string): Promise<AuthTo
   const params = new URLSearchParams({
     grant_type: 'authorization_code',
     code,
-    client_id: import.meta.env.VITE_EVE_CLIENT_ID,
+    client_id: getClientId(),
     code_verifier: verifier,
   })
   const res = await fetch(`${ssoBase}/oauth/token`, {


### PR DESCRIPTION
## Zusammenfassung
- speichert EVE Client-ID auf Wunsch im Browser
- passt Auth-Logik an und ergänzt README

## Testanweisungen
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684316e3713c8328b5d0bb61cebb6b44