### PR TITLE
Fix asset paths for GitHub Pages

### DIFF
--- a/web-isk/vite.config.ts
+++ b/web-isk/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/testing/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- configure Vite to use the repository sub-path

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68432314a70483289f445980ec57a41f