### PR TITLE
Add config for SSO login

### DIFF
--- a/web-isk/README.md
+++ b/web-isk/README.md
@@ -7,4 +7,10 @@ VITE_EVE_CLIENT_ID=<Client-ID aus dem EVE Entwicklerportal>
 VITE_EVE_REDIRECT_URI=http://localhost:5173/
 ```
 
+Soll der Login ohne manuelle Eingabe der ID erfolgen, kann in `public/eveconfig.js` eine feste `clientId` hinterlegt werden:
+
+```javascript
+window.eveConfig = { clientId: 'PASTE-ID-HERE' }
+```
+
 Im Anschluss startet man die Entwicklungsumgebung mit `npm run dev`. Der Login erfolgt über die Schaltfläche "Mit EVE einloggen". Nach erfolgreicher Anmeldung können über "Wallet laden" erste Daten angezeigt werden.

--- a/web-isk/index.html
+++ b/web-isk/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/eveconfig.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/web-isk/public/eveconfig.js
+++ b/web-isk/public/eveconfig.js
@@ -1,0 +1,1 @@
+window.eveConfig = { clientId: '' }

--- a/web-isk/src/auth.ts
+++ b/web-isk/src/auth.ts
@@ -8,6 +8,8 @@ export interface AuthToken {
 const ssoBase = 'https://login.eveonline.com/v2'
 
 function getClientId(): string {
+  const globalId = (window as WindowWithConfig).eveConfig?.clientId
+  if (globalId) return globalId
   const envId = import.meta.env.VITE_EVE_CLIENT_ID
   if (envId) return envId
   const stored = localStorage.getItem('eveClientId')

--- a/web-isk/src/vite-env.d.ts
+++ b/web-isk/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface EveConfig {
+  clientId?: string
+}
+
+interface WindowWithConfig extends Window {
+  eveConfig?: EveConfig
+}


### PR DESCRIPTION
## Summary
- allow using a global `eveConfig` object for the EVE client ID
- load optional `public/eveconfig.js` before app startup
- document the new option in the README

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684325103ce08328bfba1a150d4073f8