### PR TITLE
Replace env-based SSO config

### DIFF
--- a/web-isk/.env.example
+++ b/web-isk/.env.example
@@ -1,2 +1,0 @@
-VITE_EVE_CLIENT_ID=
-VITE_EVE_REDIRECT_URI=http://localhost:5173/

--- a/web-isk/README.md
+++ b/web-isk/README.md
@@ -1,14 +1,7 @@
 # ISK Rechner
 
-Dieses Projekt ist eine einfache Single-Page-Webapp, welche Daten aus der EVE Online ESI Schnittstelle nutzt. Die Anwendung erfordert eine `.env`-Datei mit folgenden Werten:
-
-```
-VITE_EVE_CLIENT_ID=<Client-ID aus dem EVE Entwicklerportal>
-VITE_EVE_REDIRECT_URI=http://localhost:5173/
-```
-
-Die Client-ID wird nur bei der Bereitstellung hinterlegt; Benutzer der Webseite
-sehen sie nicht und müssen nichts eingeben. Beim Klick auf „Mit EVE einloggen“
-leitet die Anwendung automatisch auf die offizielle ESI-Login-Seite weiter.
+Dieses Projekt ist eine einfache Single-Page-Webapp, welche Daten aus der EVE Online ESI Schnittstelle nutzt.
+Tragen Sie Ihre Client-ID im Datei `src/config.ts` ein und passen Sie `eveRedirectUri` gegebenenfalls an.
+Beim Klick auf „Mit EVE einloggen“ leitet die Anwendung automatisch auf die offizielle ESI-Login-Seite weiter.
 
 Im Anschluss startet man die Entwicklungsumgebung mit `npm run dev`. Der Login erfolgt über die Schaltfläche "Mit EVE einloggen". Nach erfolgreicher Anmeldung können über "Wallet laden" erste Daten angezeigt werden.

--- a/web-isk/src/auth.ts
+++ b/web-isk/src/auth.ts
@@ -5,18 +5,9 @@ export interface AuthToken {
   obtainedAt: number
 }
 
+import { eveClientId, eveRedirectUri } from './config'
+
 const ssoBase = 'https://login.eveonline.com/v2'
-
-function getClientId(): string {
-  const envId = import.meta.env.VITE_EVE_CLIENT_ID
-  if (!envId) throw new Error('Missing EVE Client ID')
-  return envId
-}
-
-function getRedirectUri(): string {
-  const envUri = import.meta.env.VITE_EVE_REDIRECT_URI
-  return envUri || `${window.location.origin}/`
-}
 
 function base64UrlEncode(input: ArrayBuffer): string {
   return btoa(String.fromCharCode(...new Uint8Array(input)))
@@ -40,8 +31,8 @@ export async function generateCodeChallenge(verifier: string): Promise<string> {
 export function buildAuthorizeUrl(verifier: string, challenge: string): string {
   const params = new URLSearchParams({
     response_type: 'code',
-    client_id: getClientId(),
-    redirect_uri: getRedirectUri(),
+    client_id: eveClientId,
+    redirect_uri: eveRedirectUri,
     scope: 'esi-wallet.read_character_wallet.v1 esi-industry.read_character_jobs.v1 esi-industry.read_character_mining.v1',
     code_challenge: challenge,
     code_challenge_method: 'S256',
@@ -54,7 +45,7 @@ export async function fetchToken(code: string, verifier: string): Promise<AuthTo
   const params = new URLSearchParams({
     grant_type: 'authorization_code',
     code,
-    client_id: getClientId(),
+    client_id: eveClientId,
     code_verifier: verifier,
   })
   const res = await fetch(`${ssoBase}/oauth/token`, {

--- a/web-isk/src/config.ts
+++ b/web-isk/src/config.ts
@@ -1,0 +1,2 @@
+export const eveClientId = ''
+export const eveRedirectUri = `${window.location.origin}/`

--- a/web-isk/src/vite-env.d.ts
+++ b/web-isk/src/vite-env.d.ts
@@ -1,10 +1,5 @@
 /// <reference types="vite/client" />
 
-interface ImportMetaEnv {
-  readonly VITE_EVE_CLIENT_ID: string
-  readonly VITE_EVE_REDIRECT_URI?: string
-}
-
 interface ImportMeta {
-  readonly env: ImportMetaEnv
+  readonly env: Record<string, string>
 }


### PR DESCRIPTION
## Summary
- add static `config.ts` containing EVE SSO client settings
- use the new config in `auth.ts`
- simplify TypeScript environment typings
- remove `.env.example` and update `README`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68433120cf6483289c24ea588a323c82